### PR TITLE
chore: use custom settings for migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-   <img src="https://raw.githubusercontent.com/juneHQ/houseplant/refs/heads/master/houseplant.png" width="300">
+   <img src="./houseplant.png" width="300">
 </p>
 
 # Houseplant: Database Migrations for ClickHouse
@@ -60,11 +60,14 @@ $ pip install houseplant
 Houseplant uses the following environment variables to connect to your ClickHouse instance:
 
 - `HOUSEPLANT_ENV`: The current environment
+- `HOUSEPLANT_DIR`: The directory where migrations are stored (default: "ch")
+- `HOUSEPLANT_SCHEMA_SNAPSHOT_FILE`: The file name for the schema snapshot (default: "schema.sql")
 - `CLICKHOUSE_HOST`: Host address of your ClickHouse server (default: "localhost")
 - `CLICKHOUSE_PORT`: Port number for ClickHouse (default: 9000)
 - `CLICKHOUSE_DB`: Database name (default: "development")
 - `CLICKHOUSE_USER`: Username for authentication (default: "default")
 - `CLICKHOUSE_PASSWORD`: Password for authentication (default: "")
+- `CLICKHOUSE_CLUSTER`: Cluster name (default: not set, don't use ON CLUSTER queries)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 <p align="center">
-   <img src="./houseplant.png" width="300">
-</p>
+   <img src="https://raw.githubusercontent.com/juneHQ/houseplant/refs/heads/master/houseplant.png" width="300">
 
 # Houseplant: Database Migrations for ClickHouse
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <p align="center">
    <img src="https://raw.githubusercontent.com/juneHQ/houseplant/refs/heads/master/houseplant.png" width="300">
+</p>
 
 # Houseplant: Database Migrations for ClickHouse
 

--- a/src/houseplant/cli.py
+++ b/src/houseplant/cli.py
@@ -20,9 +20,10 @@ app = typer.Typer(
 )
 
 
-def get_houseplant() -> Houseplant:
+def get_houseplant(init: bool = False) -> Houseplant:
     houseplant = Houseplant()
-    houseplant._check_migrations_dir()
+    if not init:
+        houseplant._check_migrations_dir()
     houseplant.db._check_clickhouse_connection()
     return houseplant
 
@@ -51,7 +52,7 @@ def common(
 @app.command()
 def init():
     """Initialize a new houseplant project."""
-    hp = get_houseplant()
+    hp = get_houseplant(init=True)
     hp.init()
 
 

--- a/src/houseplant/clickhouse_client.py
+++ b/src/houseplant/clickhouse_client.py
@@ -1,6 +1,7 @@
 """ClickHouse database operations module."""
 
 import os
+import sys
 
 from clickhouse_driver import Client
 from clickhouse_driver.errors import NetworkError, ServerException
@@ -114,7 +115,7 @@ class ClickHouseClient:
             ORDER BY (version)
         """
 
-        cluster_clause = "ON CLUSTER '{cluster}'" if self.cluster is not None else ""
+        cluster_clause = f"ON CLUSTER '{self.cluster}'" if self.cluster else ""
         engine = (
             "ReplicatedReplacingMergeTree(created_at)"
             if self.cluster is not None

--- a/src/houseplant/houseplant.py
+++ b/src/houseplant/houseplant.py
@@ -108,11 +108,7 @@ class Houseplant:
                 with open(os.path.join(MIGRATIONS_DIR, migration_file), "r") as f:
                     migration = yaml.safe_load(f)
 
-                # Get migration SQL based on environment
-                migration_sql = migration.get(self.env, {}).get("up", {}).strip()
-
                 table = migration.get("table", "").strip()
-
                 if not table:
                     self.console.print(
                         "[red]✗[/red] Migration [bold red]failed[/bold red]: "
@@ -144,9 +140,16 @@ class Houseplant:
                         }
                     )
 
-                migration_sql = migration_sql.format(**format_args).strip()
+                # Get migration SQL based on environment
+                migration_env: dict = migration.get(self.env, {})
+                migration_sql = (
+                    migration_env.get("up", "").format(**format_args).strip()
+                )
+
                 if migration_sql:
-                    self.db.execute_migration(migration_sql)
+                    self.db.execute_migration(
+                        migration_sql, migration_env.get("query_settings")
+                    )
                     self.db.mark_migration_applied(migration_version)
                     self.console.print(
                         f"[green]✓[/green] Applied migration {migration_file}"
@@ -200,8 +203,6 @@ class Houseplant:
                 with open(os.path.join(MIGRATIONS_DIR, migration_file), "r") as f:
                     migration = yaml.safe_load(f)
 
-                # Get migration SQL based on environment
-                migration_sql = migration.get(self.env, {}).get("down", {}).strip()
                 table = migration.get("table", "").strip()
                 if not table:
                     self.console.print(
@@ -209,19 +210,28 @@ class Houseplant:
                         "'table' field is required in migration file"
                     )
                     return
-                migration_sql = migration_sql.format(table=table).strip()
+
+                # Get migration SQL based on environment
+                migration_env = migration.get(self.env, {})
+                migration_sql = (
+                    migration_env.get("down", {}).format(table=table).strip()
+                )
 
                 if migration_sql:
-                    self.db.execute_migration(migration_sql)
+                    self.db.execute_migration(
+                        migration_sql, migration_env.get("query_settings")
+                    )
                     self.db.mark_migration_rolled_back(migration_version)
                     self.update_schema()
                     self.console.print(
                         f"[green]✓[/green] Rolled back migration {migration_file}"
                     )
-                else:
-                    self.console.print(
-                        f"[yellow]⚠[/yellow] Empty down migration {migration_file}"
-                    )
+
+                    return
+
+                self.console.print(
+                    f"[yellow]⚠[/yellow] Empty down migration {migration_file}"
+                )
 
     def migrate(self, version: str | None = None):
         """Run migrations up to specified version."""
@@ -335,9 +345,9 @@ production:
                     processed_tables.add(table_name)
 
             # Finally dictionaries
-            for dict in dictionaries:
-                if dict[0] == table_name:
-                    dict_name = dict[0]
+            for ch_dict in dictionaries:
+                if ch_dict[0] == table_name:
+                    dict_name = ch_dict[0]
                     create_stmt = self.db.client.execute(
                         f"SHOW CREATE DICTIONARY {dict_name}"
                     )[0][0]

--- a/src/houseplant/houseplant.py
+++ b/src/houseplant/houseplant.py
@@ -243,7 +243,7 @@ class Houseplant:
             timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
 
             migration_name = name.replace(" ", "_").replace("-", "_").lower()
-            migration_file = f"ch/migrations/{timestamp}_{migration_name}.yml"
+            migration_file = f"{MIGRATIONS_DIR}/{timestamp}_{migration_name}.yml"
 
             with open(migration_file, "w") as f:
                 f.write(f"""version: "{timestamp}"
@@ -312,7 +312,7 @@ production:
             if not matching_file:
                 continue
 
-            migration_file = f"ch/migrations/{matching_file}"
+            migration_file = f"{MIGRATIONS_DIR}/{matching_file}"
             with open(migration_file) as f:
                 migration_data = yaml.safe_load(f)
 

--- a/src/houseplant/houseplant.py
+++ b/src/houseplant/houseplant.py
@@ -355,7 +355,7 @@ production:
                     processed_tables.add(table_name)
 
         # Write schema file
-        with open("ch/schema.sql", "w") as f:
+        with open(f"{HOUSEPLANT_DIR}/{HOUSEPLANT_SCHEMA_SNAPSHOT_FILE}", "w") as f:
             f.write(f"-- version: {latest_version}\n\n")
             if table_statements:
                 f.write("-- TABLES\n\n")

--- a/src/houseplant/utils.py
+++ b/src/houseplant/utils.py
@@ -1,6 +1,9 @@
 import os
 
-MIGRATIONS_DIR = "ch/migrations"
+HOUSEPLANT_DIR = os.getenv("HOUSEPLANT_DIR", "ch")
+HOUSEPLANT_SCHEMA_SNAPSHOT_FILE = os.getenv("HOUSEPLANT_SCHEMA_SNAPSHOT_FILE", "schema.sql")
+
+MIGRATIONS_DIR = os.path.join(HOUSEPLANT_DIR, "migrations")
 
 
 def get_migration_files():

--- a/tests/test_clickhouse_client.py
+++ b/tests/test_clickhouse_client.py
@@ -146,7 +146,7 @@ def test_migrations_table_structure_with_cluster(ch_client, monkeypatch):
 
     create_statement = ch_client.init_migrations_table_query()
 
-    assert "ON CLUSTER '{cluster}'" in create_statement
+    assert "ON CLUSTER 'test_cluster'" in create_statement
     assert "ENGINE = ReplicatedReplacingMergeTree" in create_statement
 
 
@@ -154,7 +154,7 @@ def test_migrations_table_structure_without_cluster(ch_client):
     """Test that migrations table is created with correct structure when using cluster."""
     create_statement = ch_client.init_migrations_table_query()
 
-    assert "ON CLUSTER '{cluster}'" not in create_statement
+    assert "ON CLUSTER" not in create_statement
     assert "ENGINE = ReplacingMergeTree" in create_statement
 
 

--- a/tests/test_houseplant.py
+++ b/tests/test_houseplant.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from houseplant.houseplant import Houseplant
+from houseplant.utils import MIGRATIONS_DIR
 
 
 @pytest.fixture
@@ -13,7 +14,7 @@ def houseplant():
 @pytest.fixture
 def test_migration(tmp_path):
     # Set up test environment
-    migrations_dir = tmp_path / "ch/migrations"
+    migrations_dir = tmp_path / MIGRATIONS_DIR
     migrations_dir.mkdir(parents=True)
     migration_file = migrations_dir / "20240101000000_test_migration.yml"
 
@@ -53,7 +54,7 @@ production:
 @pytest.fixture
 def test_migration_with_table(tmp_path):
     # Set up test environment
-    migrations_dir = tmp_path / "ch/migrations"
+    migrations_dir = tmp_path / MIGRATIONS_DIR
     migrations_dir.mkdir(parents=True)
     migration_file = migrations_dir / "20240101000000_test_settings.yml"
 
@@ -99,7 +100,7 @@ production:
 @pytest.fixture
 def test_migration_with_view(tmp_path):
     # Set up test environment
-    migrations_dir = tmp_path / "ch/migrations"
+    migrations_dir = tmp_path / MIGRATIONS_DIR
     migrations_dir.mkdir(parents=True)
     migration_file = migrations_dir / "20240101000000_test_view.yml"
 
@@ -148,7 +149,7 @@ production:
 @pytest.fixture
 def duplicate_migrations(tmp_path):
     # Set up test environment
-    migrations_dir = tmp_path / "ch/migrations"
+    migrations_dir = tmp_path / MIGRATIONS_DIR
     migrations_dir.mkdir(parents=True)
 
     # Create two migrations that modify the same table
@@ -206,7 +207,7 @@ production:
 
 @pytest.fixture
 def migration_with_settings(tmp_path):
-    migrations_dir = tmp_path / "ch/migrations"
+    migrations_dir = tmp_path / MIGRATIONS_DIR
     migrations_dir.mkdir(parents=True)
     migration_file = migrations_dir / "20240101000000_test_migration_with_settings.yml"
 
@@ -503,7 +504,7 @@ def test_migrate_up_missing_table_field(houseplant, tmp_path, mocker):
     )
 
     # Set up test environment with invalid migration
-    migrations_dir = tmp_path / "ch/migrations"
+    migrations_dir = tmp_path / MIGRATIONS_DIR
     migrations_dir.mkdir(parents=True)
     migration_file = migrations_dir / "20240101000000_invalid_migration.yml"
 
@@ -565,7 +566,7 @@ def test_migrate_down_missing_migration_file(houseplant, mocker):
 
 def test_migrate_down_missing_table_field(houseplant, tmp_path, mocker):
     # Set up test environment with invalid migration
-    migrations_dir = tmp_path / "ch/migrations"
+    migrations_dir = tmp_path / MIGRATIONS_DIR
     migrations_dir.mkdir(parents=True)
     migration_file = migrations_dir / "20240101000000_invalid_migration.yml"
 


### PR DESCRIPTION
Changes in this PR:

- feat: add settings to use a custom directory for migrations and schema file
- ref: use the cluster passed in the setting for ON CLUSTER queries
- fix: init command doesn't check for an existing migrations directory, since it's in charge of creating it